### PR TITLE
Included individual test times in output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 nose-congestion
 ===============
 
-Nose can report test execution time in its various output formats but it doesn't include the `setUp`
-or `tearDown` time, which can be substantial.
+Nose can report test execution time in its various output formats but it
+doesn't include the `setUp` or `tearDown` time, which can be substantial.
 
 Usage
 -----
@@ -20,3 +20,8 @@ After all of the tests complete, a simple table will be printed::
     ----------------------------------------------------------------------
     module.tests.FastTests                         7.187    1.659    0.000
     module.tests.SlowTests                         0.047    0.002    0.000
+
+      Total  Location
+    ----------------------------------------------------------------------
+      0.104  module.tests.SlowTests.test_method
+      0.009  module.tests.FastTests.test_method


### PR DESCRIPTION
I'm not sure if this fits within the original idea of nose-congestion but I added the output times of all tests in reverse order (longest test at top). I had a case recently where there was an infinite recursion timeout in my tests but I wasn't sure which test it was -- this helped me find it.

Happy to tweak things.
